### PR TITLE
Change player answer class from String to Answer

### DIFF
--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/Answer.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/Answer.kt
@@ -1,0 +1,3 @@
+package com.lunchee.fizzbuzz.game
+
+data class Answer(val value: String)

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGame.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGame.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 class FizzBuzzGame(private val player: FizzBuzzPlayer) {
 
     @ExperimentalCoroutinesApi
-    fun play(untilNumber: CountToNumber): Flow<String> {
+    fun play(untilNumber: CountToNumber): Flow<Answer> {
         return (1..untilNumber.value).asFlow()
             .map { player.giveAnswer(it) }
     }

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGameController.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGameController.kt
@@ -14,7 +14,7 @@ class FizzBuzzGameController(private val game: FizzBuzzGame) {
 
     @ExperimentalCoroutinesApi
     @GetMapping
-    fun play(@RequestParam countTo: Int): Flux<String> {
+    fun play(@RequestParam countTo: Int): Flux<Answer> {
         return game.play(CountToNumber(countTo)).asFlux()
     }
 }

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzPlayer.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzPlayer.kt
@@ -4,13 +4,13 @@ import org.springframework.stereotype.Service
 
 @Service
 class FizzBuzzPlayer {
-    fun giveAnswer(number: Int): String {
+    fun giveAnswer(number: Int): Answer {
         val answers = arrayListOf<String>()
 
         if (number % 3 == 0) answers.add("Fizz")
         if (number % 5 == 0) answers.add("Buzz")
         if (answers.isEmpty()) answers.add(number.toString())
 
-        return answers.joinToString(separator = " ")
+        return Answer(answers.joinToString(separator = " "))
     }
 }

--- a/src/test/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGameTest.kt
+++ b/src/test/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzGameTest.kt
@@ -22,21 +22,21 @@ class FizzBuzzGameTest {
 
     @Test
     fun `should return one value if counting to 1`() {
-        given(player.giveAnswer(1)).willReturn("One?")
+        given(player.giveAnswer(1)).willReturn(Answer("One?"))
 
         runBlocking {
             assertThat(game().play(CountToNumber(1)).toList())
-                .containsExactly("One?")
+                .containsExactly(Answer("One?"))
         }
     }
 
     @Test
     fun `should return two values if counting to 2`() {
-        given(player.giveAnswer(anyInt())).willAnswer { it.arguments[0].toString() }
+        given(player.giveAnswer(anyInt())).willAnswer { Answer(it.arguments[0].toString()) }
 
         runBlocking {
             assertThat(game().play(CountToNumber(2)).toList())
-                .containsExactly("1", "2")
+                .containsExactly(Answer("1"), Answer("2"))
         }
     }
 }

--- a/src/test/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzPlayerTest.kt
+++ b/src/test/kotlin/com/lunchee/fizzbuzz/game/FizzBuzzPlayerTest.kt
@@ -9,26 +9,26 @@ class FizzBuzzPlayerTest {
 
     @Test
     fun `should answer "1" for 1`() {
-        assertThat(player().giveAnswer(1)).isEqualTo("1")
+        assertThat(player().giveAnswer(1)).isEqualTo(Answer("1"))
     }
 
     @Test
     fun `should answer "2" for 2`() {
-        assertThat(player().giveAnswer(2)).isEqualTo("2")
+        assertThat(player().giveAnswer(2)).isEqualTo(Answer("2"))
     }
 
     @Test
     fun `should answer "Fizz" for 3`() {
-        assertThat(player().giveAnswer(3)).isEqualTo("Fizz")
+        assertThat(player().giveAnswer(3)).isEqualTo(Answer("Fizz"))
     }
 
     @Test
     fun `should answer "Buzz" for 5`() {
-        assertThat(player().giveAnswer(5)).isEqualTo("Buzz")
+        assertThat(player().giveAnswer(5)).isEqualTo(Answer("Buzz"))
     }
 
     @Test
     fun `should answer "Fizz Buzz" for 15`() {
-        assertThat(player().giveAnswer(15)).isEqualTo("Fizz Buzz")
+        assertThat(player().giveAnswer(15)).isEqualTo(Answer("Fizz Buzz"))
     }
 }


### PR DESCRIPTION
Because when strings are returned as Flux, a client cannot understand
when one string ends and another one begins and reads result as one
string.