### PR TITLE
Add Rest Docs snippet generation to Controller Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <version>${coroutinesVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-webtestclient</artifactId>
+            <version>2.0.3.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -157,6 +163,58 @@
                         <include>*IT</include>
                     </includes>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>book</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>2.0.3.RELEASE</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/static/docs
+                            </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/generated-docs
+                                    </directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/CountToNumber.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/CountToNumber.kt
@@ -2,6 +2,6 @@ package com.lunchee.fizzbuzz.game
 
 data class CountToNumber(val value: Int) {
     init {
-        require(value >= 1) { "Number should be greater than zero." }
+        require(value >= 1) { "'Count to number' should be greater than zero." }
     }
 }

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -1,0 +1,4 @@
+spring.test.restdocs:
+  uriScheme: https
+  uriHost: ${BASE_URL}
+  uriPort: ${PORT}

--- a/src/test/kotlinit/com/lunchee/fizzbuzz/game/GameControllerIT.kt
+++ b/src/test/kotlinit/com/lunchee/fizzbuzz/game/GameControllerIT.kt
@@ -7,18 +7,24 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.MediaType.APPLICATION_STREAM_JSON
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.requestParameters
+import org.springframework.restdocs.snippet.Attributes.key
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.reactive.server.WebTestClient
-import reactor.core.publisher.Flux
-import reactor.test.StepVerifier
 
 @ExperimentalCoroutinesApi
 @WebFluxTest(controllers = [GameController::class])
 @ExtendWith(SpringExtension::class)
+@AutoConfigureRestDocs
 open class GameControllerIT {
 
     @Autowired
@@ -28,31 +34,54 @@ open class GameControllerIT {
     private lateinit var game: Game
 
     @Test
-    fun `should return answers as array of strings`() {
-        given(game.play(CountToNumber(5))).willReturn(answers("1", "2", "Fizz", "4", "Buzz"))
+    fun `should return answers as a stream`() {
+        given(game.play(CountToNumber(5))).willReturn(answersFlux("1", "2", "Fizz", "4", "Buzz"))
 
-        val response: Flux<Answer> = testClient
+        testClient
             .get().uri("/game?countTo=5").accept(APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isOk
-            .returnResult(Answer::class.java)
-            .responseBody
-
-        StepVerifier.create(response)
-            .expectNext(Answer("1"), Answer("2"), Answer("Fizz"), Answer("4"), Answer("Buzz"))
-            .expectComplete()
-            .verify()
+            .expectBodyList(Answer::class.java)
+            .hasSize(5)
+            .contains(*answers("1", "2", "Fizz", "4", "Buzz"))
+            .consumeWith<WebTestClient.ListBodySpec<Answer>>(
+                document(
+                    "game-ok",
+                    requestParameters(
+                        parameterWithName("countTo")
+                            .description("Number to play up to, inclusive.")
+                            .attributes(key("constraints").value("Must be greater than zero"))
+                    ),
+                    responseFields(
+                        fieldWithPath("value").description("Answer of a Player")
+                    )
+                )
+            )
     }
 
-    private fun answers(vararg answers: String): Flow<Answer> {
+    private fun answersFlux(vararg answers: String): Flow<Answer> {
         return answers.asSequence()
             .map { Answer(it) }
             .asFlow()
+    }
+
+    private fun answers(vararg answers: String): Array<Answer> {
+        return answers.map { Answer(it) }.toTypedArray()
     }
 
     @Test
     fun `should return 422 Unprocessable Entity if Count To is less than 1`() {
         testClient.get().uri("/game?countTo=0").accept(APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isEqualTo(UNPROCESSABLE_ENTITY)
-            .expectBody().jsonPath("$.message").isNotEmpty
+            .expectBody()
+            .consumeWith(
+                document(
+                    "game-count-0",
+                    responseFields(
+                        fieldWithPath("code").description("HTTP Response Status Value"),
+                        fieldWithPath("error").description("HTTP Response Status Name"),
+                        fieldWithPath("message").description("Error message")
+                    )
+                )
+            )
     }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
@@ -1,0 +1,11 @@
+|===
+|Parameter|Description|Constraints
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{constraints}}{{/tableCellContent}}
+
+{{/parameters}}
+|===
+


### PR DESCRIPTION
Rest Docs verifies request and response contents and generates snippets
which can then be used to generate a documentation for API.