### PR TITLE
Add produces = [APPLICATION_STREAM_JSON_VALUE] to Game Controller

### DIFF
--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/Game.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/Game.kt
@@ -1,17 +1,22 @@
 package com.lunchee.fizzbuzz.game
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class Game(private val player: Player) {
 
+    private val log = LoggerFactory.getLogger(Game::class.java)
+
     @ExperimentalCoroutinesApi
     fun play(untilNumber: CountToNumber): Flow<Answer> {
         return (1..untilNumber.value).asFlow()
             .map { player.giveAnswer(it) }
+            .onStart { log.debug("Game started") }
+            .onCompletion { log.debug("Game ended") }
+            .flowOn(Dispatchers.Default)
     }
 }

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/GameController.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/GameController.kt
@@ -2,6 +2,7 @@ package com.lunchee.fizzbuzz.game
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactor.asFlux
+import org.springframework.http.MediaType.APPLICATION_STREAM_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -13,7 +14,7 @@ import reactor.core.publisher.Flux
 class GameController(private val game: Game) {
 
     @ExperimentalCoroutinesApi
-    @GetMapping
+    @GetMapping(produces = [APPLICATION_STREAM_JSON_VALUE])
     fun play(@RequestParam countTo: Int): Flux<Answer> {
         return game.play(CountToNumber(countTo)).asFlux()
     }

--- a/src/test/kotlinit/com/lunchee/fizzbuzz/game/GameControllerIT.kt
+++ b/src/test/kotlinit/com/lunchee/fizzbuzz/game/GameControllerIT.kt
@@ -39,6 +39,7 @@ open class GameControllerIT {
         testClient
             .get().uri("/game?countTo=5").accept(APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isOk
+            .expectHeader().contentType("application/stream+json;charset=UTF-8")
             .expectBodyList(Answer::class.java)
             .hasSize(5)
             .contains(*answers("1", "2", "Fizz", "4", "Buzz"))


### PR DESCRIPTION
Otherwise, Spring does not return answers one by one, but instead does
it in one batch. Moreover, it does not cancel work if a request is
cancelled by a client.

Also, answers will flow on the Default coroutine dispatcher to unload
Netty event loop threads.

Plus, added some debug information about game start and end.