### PR TITLE
Retrieve numbers to answer as a stream

### DIFF
--- a/src/main/asciidoc/api-doc.adoc
+++ b/src/main/asciidoc/api-doc.adoc
@@ -10,7 +10,7 @@ The service returns answers from `1` to the provided number.
 include::{snippets}/game-start/curl-request.adoc[]
 include::{snippets}/game-start/request-parameters.adoc[]
 
-Response comes as a stream of JSON objects:
+Response is a stream of JSON objects:
 include::{snippets}/game-start/http-response.adoc[]
 include::{snippets}/game-start/response-fields.adoc[]
 
@@ -23,7 +23,7 @@ Response is a single answer:
 include::{snippets}/get-single-answer/http-response.adoc[]
 
 === Several Answers
-To get answers for several numbers, use the following request with numbers sent as an array in request body:
+To get answers for several numbers, use the following request with numbers sent as a stream in request body:
 include::{snippets}/get-multiple-answers/curl-request.adoc[]
 include::{snippets}/get-multiple-answers/request-fields.adoc[]
 

--- a/src/main/kotlin/com/lunchee/fizzbuzz/game/GameController.kt
+++ b/src/main/kotlin/com/lunchee/fizzbuzz/game/GameController.kt
@@ -1,7 +1,7 @@
 package com.lunchee.fizzbuzz.game
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.asFlux
 import org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE
 import org.springframework.http.MediaType.APPLICATION_STREAM_JSON_VALUE
@@ -21,9 +21,10 @@ class GameController(private val game: Game) {
     @ExperimentalCoroutinesApi
     @PostMapping(
         path = ["/answers"],
+        consumes = [APPLICATION_STREAM_JSON_VALUE],
         produces = [APPLICATION_STREAM_JSON_VALUE]
     )
-    fun getAnswers(@RequestBody numbers: List<NumberToAnswer>): Flux<Answer> {
+    fun getAnswers(@RequestBody numbers: Flux<NumberToAnswer>): Flux<Answer> {
         return game.getAnswers(numbers.map { it.value }.asFlow()).asFlux()
     }
 


### PR DESCRIPTION
It was not working with Rest Docs (body was empty) because it was not
collected in the test and, thus, not generated and sent at all.