### PR TITLE
Do maven resolve dependencies on Travis install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ branches:
   only:
     - master
 
-script: mvn verify -B
-
 cache:
   directories:
     - $HOME/.m2
+
+install: mvn dependency:resolve
+
+script: mvn verify -B


### PR DESCRIPTION
By default Travis does "mvn install" during install phase to resolve
dependencies, which is overkill, because later it executes same stuff
with "mvn verify".